### PR TITLE
Control package exports and add import behavior tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .venv/
 src/pkg.egg-info/
+src/pkg_resolution_exploration.egg-info/

--- a/src/examples_pkg/__init__.py
+++ b/src/examples_pkg/__init__.py
@@ -1,2 +1,4 @@
 __all__ = []
 print("Importing examples_pkg package")
+
+from . import subpkg2

--- a/src/examples_pkg/__init__.py
+++ b/src/examples_pkg/__init__.py
@@ -1,0 +1,2 @@
+__all__ = []
+print("Importing examples_pkg package")

--- a/src/examples_pkg/subpkg1/__init__.py
+++ b/src/examples_pkg/subpkg1/__init__.py
@@ -1,0 +1,3 @@
+print("Importing examples_pkg.subpkg1")
+__all__ = ["module1"]
+from . import module1

--- a/src/examples_pkg/subpkg1/module1.py
+++ b/src/examples_pkg/subpkg1/module1.py
@@ -1,0 +1,2 @@
+def greet_subpkg1():
+    print("Hello from examples_pkg.subpkg1.module1")

--- a/src/examples_pkg/subpkg2/__init__.py
+++ b/src/examples_pkg/subpkg2/__init__.py
@@ -1,0 +1,3 @@
+print("Importing examples_pkg.subpkg2")
+__all__ = ["module2"]
+from . import module2

--- a/src/examples_pkg/subpkg2/module2.py
+++ b/src/examples_pkg/subpkg2/module2.py
@@ -1,0 +1,2 @@
+def greet_subpkg2():
+    print("Hello from examples_pkg.subpkg2.module2")

--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,13 @@ def main():
 
     import pkg.b
 
+    import examples_pkg
+    import examples_pkg.subpkg1
+    import examples_pkg.subpkg2
+
+    examples_pkg.subpkg1.module1.greet_subpkg1()
+    examples_pkg.subpkg2.module2.greet_subpkg2()
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_examples_pkg_init.py
+++ b/tests/test_examples_pkg_init.py
@@ -1,9 +1,5 @@
 import pytest
-import sys
-import os
-
-# Ensure src is on path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+# tests assume project installed in editable mode via 'pip install -e .[dev]'
 
 import examples_pkg
 import examples_pkg.subpkg1 as sp1

--- a/tests/test_examples_pkg_init.py
+++ b/tests/test_examples_pkg_init.py
@@ -1,0 +1,39 @@
+import pytest
+import sys
+import os
+
+# Ensure src is on path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+import examples_pkg
+import examples_pkg.subpkg1 as sp1
+import examples_pkg.subpkg2 as sp2
+
+import examples_pkg.subpkg1.module1 as m1
+import examples_pkg.subpkg2.module2 as m2
+
+def test_examples_pkg_all():
+    # examples_pkg __all__ should be empty by default
+    assert examples_pkg.__all__ == []
+
+
+def test_direct_module_import():
+    # direct import of module1 should succeed
+    assert hasattr(m1, 'greet_subpkg1')
+    m1.greet_subpkg1()
+
+
+def test_indirect_module1_import_via_init():
+    # accessing module1 via package attr should succeed after explicit import in __init__.py
+    assert hasattr(sp1, 'module1')
+    sp1.module1.greet_subpkg1()
+
+def test_direct_module2_import():
+    assert hasattr(m2, 'greet_subpkg2')
+    m2.greet_subpkg2()
+
+
+def test_indirect_module2_import_via_init():
+    # accessing module2 via package attr should succeed after explicit import in __init__.py
+    assert hasattr(sp2, 'module2')
+    sp2.module2.greet_subpkg2()


### PR DESCRIPTION
## Summary

- Introduce `examples_pkg` with import tracing and controlled exports
- Add subpackages demonstrating `__init__.py` and `__all__` usage
- Update `main.py` to demo import behavior
- Add tests validating import behaviors and package interface control

## Rationale

By explicitly exposing submodules via `__all__`, we teach learners how package interfaces are controlled and prevent unintended attribute errors.

## Pedagogical Value

- Demonstrates the role of `__init__.py` beyond making a directory a package
- Shows how `__all__` influences `from package import *` and attribute visibility
- Illustrates test-driven exploration of package import behaviors

## Usage Notes

- Run `python main.py` to see import tracing and module greetings
- Ensure `pytest` is installed via dev dependencies and run `pytest` to validate behavior

🤖 Generated with [opencode](https://opencode.ai)